### PR TITLE
fix: lock runs-on in update-feeds gh workflow to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/update_feeds.yml
+++ b/.github/workflows/update_feeds.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-feeds:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout repository


### PR DESCRIPTION
https://github.com/actions/setup-python/issues/162