### PR TITLE
fix: Append .jpg file endings to squareimages on podcast update

### DIFF
--- a/docs/rss/politisk_kvarter.xml
+++ b/docs/rss/politisk_kvarter.xml
@@ -7,10 +7,19 @@
     <itunes:explicit>no</itunes:explicit>
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>nrk-pod-feeder v1.3.0 (with help from python-podgen)</generator>
-    <lastBuildDate>Wed, 31 May 2023 06:30:23 +0000</lastBuildDate>
-    <pubDate>Wed, 31 May 2023 08:00:00 +0200</pubDate>
+    <lastBuildDate>Thu, 01 Jun 2023 06:17:55 +0000</lastBuildDate>
+    <pubDate>Thu, 01 Jun 2023 08:00:00 +0200</pubDate>
     <itunes:block>Yes</itunes:block>
-    <itunes:image href="https://gfx.nrk.no/5Bk4IWQVfNZTVR17iLNoPgQ6DNWEL_MiLb8yfHpm9Gjg"/>
+    <itunes:image href="https://gfx.nrk.no/5Bk4IWQVfNZTVR17iLNoPgQ6DNWEL_MiLb8yfHpm9Gjg.jpg"/>
+    <item>
+      <title>Lærere får bruke fysisk makt mot elever</title>
+      <description><![CDATA[Ny opplæringslov vedtas og nå skal lærerne også få bruke makt når elever går løs på andre elever. Men er det så lett? og når kommer loven? Frp vil være strengere. 
+Og hva skjer nå med eksamen etter datatrøbbelet  forrige uke?]]></description>
+      <guid isPermaLink="false">https://podkast.nrk.no/fil/politisk_kvarter/a88188b7-5168-4783-9bb3-724ac1b5d7ad_0_ID192MP3.mp3</guid>
+      <enclosure url="https://podkast.nrk.no/fil/politisk_kvarter/a88188b7-5168-4783-9bb3-724ac1b5d7ad_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
+      <itunes:duration>13:23</itunes:duration>
+      <pubDate>Thu, 01 Jun 2023 08:00:00 +0200</pubDate>
+    </item>
     <item>
       <title>Byråd i Bergen vil ha Bybane, ikke ferjefri vei</title>
       <description><![CDATA[Et svik mot Vestlandet. Næringsforeningen i Stavanger er ikke nådig mot Byrådet i Bergen, som ønsker å skrote Hordfast-prosjektet.
@@ -94,15 +103,6 @@ Betyr det noe for deg hvem av dem som får en hånd på rattet i din kommune?]]>
       <enclosure url="https://podkast.nrk.no/fil/politisk_kvarter/df2522e8-2201-4b3f-8a73-062c974bec55_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
       <itunes:duration>15:37</itunes:duration>
       <pubDate>Tue, 16 May 2023 08:00:00 +0200</pubDate>
-    </item>
-    <item>
-      <title>Skoledebatt: Fravær, skjerm og lekser</title>
-      <description><![CDATA[Arbeiderpartiet har vedtatt å endre på fraværsgrensa og vil at kommunepolitikerne kan gi leksefri.  
-Samtidig beskylder de Høyre for å ha latt 100.000 unge voksne utenfor jobb og utdanning i stikken.]]></description>
-      <guid isPermaLink="false">https://podkast.nrk.no/fil/politisk_kvarter/42db9667-9d60-46a1-ac19-20e4c215e4cb_0_ID192MP3.mp3</guid>
-      <enclosure url="https://podkast.nrk.no/fil/politisk_kvarter/42db9667-9d60-46a1-ac19-20e4c215e4cb_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
-      <itunes:duration>15:36</itunes:duration>
-      <pubDate>Mon, 15 May 2023 08:00:00 +0200</pubDate>
     </item>
   </channel>
 </rss>

--- a/generate_feeds.py
+++ b/generate_feeds.py
@@ -27,7 +27,7 @@ def get_podcast(podcast_id, season, feeds_dir, ep_count = 10):
         return None
 
     original_title = metadata["series"]["titles"]["title"]
-    image = metadata["series"]["squareImage"][4]["url"]
+    image = f"{metadata['series']['squareImage'][4]['url']}.jpg"
     website = metadata["_links"]["share"]["href"]
 
     logging.debug(f"  Title: {original_title}")


### PR DESCRIPTION
Fixes podgen warnings, and probably improves podcast client support.