### PR TITLE
feat: Set discovery workflow to commit without PR

### DIFF
--- a/.github/workflows/discover_feeds.yml
+++ b/.github/workflows/discover_feeds.yml
@@ -29,27 +29,38 @@ jobs:
       - name: Execute discovery script
         run: python discover_feeds.py
 
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v4
-        with:
-          title: "chore(auto): Update podcast configuration"
-          body: "Automated discovery routine found new podcasts or changes to existing podcast feeds."
-          branch: update-podcast-configuration
-          commit-message: "chore(auto): Update podcast configuration"
-          committer: nrk-pod-feeds auto-discovery <actions@github.com>
-          labels: enhancement
-          delete-branch: true
-          add-paths: |
-            podcasts.json
+      # - name: Create Pull Request
+      #   id: cpr
+      #   uses: peter-evans/create-pull-request@v4
+      #   with:
+      #     title: "chore(auto): Update podcast configuration"
+      #     body: "Automated discovery routine found new podcasts or changes to existing podcast feeds."
+      #     branch: update-podcast-configuration
+      #     commit-message: "chore(auto): Update podcast configuration"
+      #     committer: nrk-pod-feeds auto-discovery <actions@github.com>
+      #     labels: enhancement
+      #     delete-branch: true
+      #     add-paths: |
+      #       podcasts.json
       
-      - name: Checkout PR branch
-        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' }}
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: update-podcast-configuration
+      # - name: Checkout PR branch
+      #   if: ${{ steps.cpr.outputs.pull-request-operation == 'created' }}
+      #   uses: actions/checkout@v3
+      #   with:
+      #     fetch-depth: 0
+      #     ref: update-podcast-configuration
 
-      - name: Run tests on PR branch
-        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' }}
-        run: pytest -vv
+      # - name: Run tests on PR branch
+      #   if: ${{ steps.cpr.outputs.pull-request-operation == 'created' }}
+      #   run: pytest -vv
+
+      - name: Execute feed generation script (smoke test)
+        run: python generate_feeds.py
+
+      - name: Auto-commit changes and push
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore(auto): Update podcast configuration"
+          commit_author: nrk-pod-feeds auto-discovery <actions@github.com>
+          repository: .
+          file_pattern: 'podcasts.json'

--- a/podcasts.json
+++ b/podcasts.json
@@ -859,7 +859,7 @@
         "id": "radio_moerch",
         "title": "De 10 siste fra Radio Mørch",
         "season": null,
-        "enabled": false
+        "enabled": true
     },
     {
         "id": "radiodokumentaren",

--- a/podcasts.json
+++ b/podcasts.json
@@ -859,7 +859,7 @@
         "id": "radio_moerch",
         "title": "De 10 siste fra Radio Mørch",
         "season": null,
-        "enabled": true
+        "enabled": false
     },
     {
         "id": "radiodokumentaren",


### PR DESCRIPTION
Discovery workflow commits directly to base branch without PR, removing the need for approvals on config updates.