### PR TITLE
chore: Bump gha runtime to ubuntu 22.04, python v3.11.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7.7'
+          python-version: '3.11.5'
           cache: 'pip'
           
       - name: Install Python packages

--- a/.github/workflows/discover_feeds.yml
+++ b/.github/workflows/discover_feeds.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-feeds:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout repository
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7.7'
+          python-version: '3.11.5'
           cache: 'pip'
           
       - name: Install Python packages

--- a/.github/workflows/update_feeds.yml
+++ b/.github/workflows/update_feeds.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-feeds:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout repository
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7.7'
+          python-version: '3.11.5'
           cache: 'pip'
           
       - name: Install Python packages


### PR DESCRIPTION
See PR #98 .