### PR TITLE
Add Urix på lørdag (radioversjon)

### DIFF
--- a/podcasts.json
+++ b/podcasts.json
@@ -1439,7 +1439,13 @@
     },
     {
         "id": "verden_paa_loerdag",
-        "title": "De 10 siste fra Urix på lørdag",
+        "title": "De 10 siste fra Urix (podcast)",
+        "season": null,
+        "enabled": true
+    },
+    {
+        "id": "urix-paa-loerdag",
+        "title": "De 10 siste fra Urix (radioversjon)",
         "season": null,
         "enabled": true
     },


### PR DESCRIPTION
Urix used to have one feed for both the podcast (~15 mins) and the radio broadcast (which is 1 hour, which includes the podcast segment). Now they have split the feed in two, and this commit adds the 1 hour radio show back.