### PR TITLE
fix(filmpolitiet): missing custom seasons

### DIFF
--- a/docs/feeds.js
+++ b/docs/feeds.js
@@ -316,7 +316,7 @@ const feeds = [
   {
     "id": "filmpolitiet",
     "title": "De 10 siste fra Filmpolitiet",
-    "season": "LATEST_SEASON",
+    "season": null,
     "enabled": true
   },
   {

--- a/docs/rss/filmpolitiet.xml
+++ b/docs/rss/filmpolitiet.xml
@@ -8,7 +8,7 @@
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>nrk-pod-feeder v1.5.1 (with help from python-podgen)</generator>
     <language>no</language>
-    <lastBuildDate>Thu, 24 Apr 2025 12:57:56 +0000</lastBuildDate>
+    <lastBuildDate>Sun, 27 Apr 2025 13:24:00 +0000</lastBuildDate>
     <pubDate>Thu, 24 Apr 2025 14:00:00 +0200</pubDate>
     <itunes:block>Yes</itunes:block>
     <itunes:image href="https://gfx.nrk.no/zsc9T95MW0C8PXLzZ5wEwAaWveum9n42UivuRALUOxyA.jpg"/>
@@ -22,6 +22,24 @@
       <itunes:image href="https://gfx.nrk.no/EXgX9nxvwXxlIKXPXxR1fAs8XkF5XRRu_rbzGiNqgJiQ.jpg"/>
     </item>
     <item>
+      <title>The Last of Us: S2 E1-E2</title>
+      <description><![CDATA[Seerne er i sjokk etter starten på «The Last of Us» s2 på Max. Sigurd og Marte diskuterer episodene og det hardtslående TV-øyeblikket!]]></description>
+      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/b0debd2b-c13b-4c71-a1a6-2d4348d26941_0_ID192MP3.mp3</guid>
+      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/b0debd2b-c13b-4c71-a1a6-2d4348d26941_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
+      <itunes:duration>02:19:47</itunes:duration>
+      <pubDate>Tue, 22 Apr 2025 18:00:00 +0200</pubDate>
+      <itunes:image href="https://gfx.nrk.no/uUoW5DCCYkjtVyOcM0HZPABOFWDDk-88bAwGbPbwcLEA.jpg"/>
+    </item>
+    <item>
+      <title>The Wheel of Time: S3 E7-E8</title>
+      <description><![CDATA[Det er finale! De to siste episodene av sesong 3 av «The Wheel of Time» hadde både store høydepunkt og irritasjonsmomenter.]]></description>
+      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/f8de2b93-4946-41d1-8920-ed6cae3552f6_0_ID192MP3.mp3</guid>
+      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/f8de2b93-4946-41d1-8920-ed6cae3552f6_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
+      <itunes:duration>03:22:30</itunes:duration>
+      <pubDate>Tue, 22 Apr 2025 14:00:00 +0200</pubDate>
+      <itunes:image href="https://gfx.nrk.no/3At6htVZ6oHyUoSVMLQtigm6Fj6TwcO_nRGUCLyMeg6A.jpg"/>
+    </item>
+    <item>
       <title>The Last of Us S2: Du blir emosjonelt ødelagt</title>
       <description><![CDATA[Marte anmelder sesong 2 av det postapokalyptisk dramaet til terningkast 5!]]></description>
       <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/69ee5553-4283-4465-948f-8acace8eb2cc_0_ID192MP3.mp3</guid>
@@ -29,6 +47,15 @@
       <itunes:duration>21:04</itunes:duration>
       <pubDate>Tue, 22 Apr 2025 08:43:00 +0200</pubDate>
       <itunes:image href="https://gfx.nrk.no/PeqeW0f9ZKI0twTfaz3Icw0_0ilQq-UT5IOXFb6Zusaw.jpg"/>
+    </item>
+    <item>
+      <title>Diskuter The Last of Us S2 med oss!</title>
+      <description><![CDATA[Sigurd og Marte følger sesong 2 av «The Last of Us» hver uke! Bli med å diskutere den postapokalyptiske dramaserien med oss!]]></description>
+      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/ac6da480-5cae-4b1d-b44f-ebea96ea8671_0_ID192MP3.mp3</guid>
+      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/ac6da480-5cae-4b1d-b44f-ebea96ea8671_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
+      <itunes:duration>02:48</itunes:duration>
+      <pubDate>Thu, 10 Apr 2025 14:05:00 +0200</pubDate>
+      <itunes:image href="https://gfx.nrk.no/uUoW5DCCYkjtVyOcM0HZPABOFWDDk-88bAwGbPbwcLEA.jpg"/>
     </item>
     <item>
       <title>Årets påskekrim - fra best til verst!</title>
@@ -40,6 +67,15 @@
       <itunes:image href="https://gfx.nrk.no/1p3SChtdVjvcXbxbGMdVSA0cI5DD5gP3i4wWN9xLXYMQ.jpg"/>
     </item>
     <item>
+      <title>The Wheel of Time: S3 E6 - Shadow In the Night</title>
+      <description><![CDATA[«The hills of Tanchico! The hills of Tanchico, HEY!». Vi elsker når fantasy møter musikal i skjønn forening! Sigurd og Marte diskuterer ukas episode av «The Wheel of Time».]]></description>
+      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/2304d5ee-9ff7-4803-b490-a38f6640f488_0_ID192MP3.mp3</guid>
+      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/2304d5ee-9ff7-4803-b490-a38f6640f488_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
+      <itunes:duration>02:50:33</itunes:duration>
+      <pubDate>Tue, 08 Apr 2025 14:00:00 +0200</pubDate>
+      <itunes:image href="https://gfx.nrk.no/3At6htVZ6oHyUoSVMLQtigm6Fj6TwcO_nRGUCLyMeg6A.jpg"/>
+    </item>
+    <item>
       <title>Bosch: Legacy: TV-rutas tøffeste krimhelt</title>
       <description><![CDATA[Ti år med storbykrim fra Los Angeles er over! Sigurd triller terningkast 5 til den siste sesongen av «Bosch».]]></description>
       <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/3711c2dc-fbd0-40c6-a13d-b8e33d42fe0c_0_ID192MP3.mp3</guid>
@@ -49,6 +85,15 @@
       <itunes:image href="https://gfx.nrk.no/VemE_X5RWK6yLfZvpjeFgw3RcIqxcST2qobUu-YuyoyQ.jpg"/>
     </item>
     <item>
+      <title>The Wheel of Time: S3 E5  - Tel'aran'rhiod</title>
+      <description><![CDATA[Sigurd og Marte kaster seg ut i drømmenes verden og diskuterer episode 5 av «The Wheel of Time» S3.]]></description>
+      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/5594d2db-8096-4c5f-81a7-8fa591c5a71b_0_ID192MP3.mp3</guid>
+      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/5594d2db-8096-4c5f-81a7-8fa591c5a71b_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
+      <itunes:duration>02:56:09</itunes:duration>
+      <pubDate>Tue, 01 Apr 2025 14:00:00 +0200</pubDate>
+      <itunes:image href="https://gfx.nrk.no/3At6htVZ6oHyUoSVMLQtigm6Fj6TwcO_nRGUCLyMeg6A.jpg"/>
+    </item>
+    <item>
       <title>Adolescence: Opprivende krimkunst</title>
       <description><![CDATA[Terningkast 6 til Netflix-serien «Adolescence»! Et kruttsterkt krimdrama med imponerende formgrep og gnistrende godt skuespill.]]></description>
       <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/41f87144-d4b9-4c9e-8923-95faa7998778_0_ID192MP3.mp3</guid>
@@ -56,51 +101,6 @@
       <itunes:duration>32:52</itunes:duration>
       <pubDate>Thu, 27 Mar 2025 14:00:00 +0100</pubDate>
       <itunes:image href="https://gfx.nrk.no/Y2y0uFaxZ0KV9f8VscUR-QP4IP3RXvLKK7NPJ-UI_BVQ.jpg"/>
-    </item>
-    <item>
-      <title>The Residence: Festlig kosekrim i Det hvite hus</title>
-      <description><![CDATA[Uzo Adubas komiske talent kommer virkelig til sin rett som detektiv Cordelia Cupp i «The Residence».]]></description>
-      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/a54d9205-abde-4fb7-9b63-5550129a4fb9_0_ID192MP3.mp3</guid>
-      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/a54d9205-abde-4fb7-9b63-5550129a4fb9_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
-      <itunes:duration>22:11</itunes:duration>
-      <pubDate>Thu, 20 Mar 2025 14:00:00 +0100</pubDate>
-      <itunes:image href="https://gfx.nrk.no/L5vpS0GbFrecisOUjJPWmwpb8Gn07JSZBEwvgdEtKL1g.jpg"/>
-    </item>
-    <item>
-      <title>The Wheel of Time S3: Bedre enn noensinne!</title>
-      <description><![CDATA[Fantasystorserien på Prime Video er ute med sin beste sesong til nå, men Marte har fortsatt ting å plukke på.]]></description>
-      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/1911a0cc-0455-4c42-b39b-1395c8145884_0_ID192MP3.mp3</guid>
-      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/1911a0cc-0455-4c42-b39b-1395c8145884_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
-      <itunes:duration>25:12</itunes:duration>
-      <pubDate>Thu, 13 Mar 2025 14:00:00 +0100</pubDate>
-      <itunes:image href="https://gfx.nrk.no/MJogRuX2OZA1EyQxcwzmCgKWiFSW6I4GIZbao3LWkwyQ.jpg"/>
-    </item>
-    <item>
-      <title>Den stygge stesøsteren: Blodig og lekkert eventyr</title>
-      <description><![CDATA[«Den stygge stesøsteren» er en ny vri på Askepott-fortellingen, som på ingen måte er en barnefilm!]]></description>
-      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/88aab304-056a-4af4-b070-6a9377b22082_0_ID192MP3.mp3</guid>
-      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/88aab304-056a-4af4-b070-6a9377b22082_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
-      <itunes:duration>19:42</itunes:duration>
-      <pubDate>Thu, 06 Mar 2025 14:00:00 +0100</pubDate>
-      <itunes:image href="https://gfx.nrk.no/RaYMQy_p1w_ku3w9pxlSqgXhAN-lEJOgeYHC_qULnAKw.jpg"/>
-    </item>
-    <item>
-      <title>The Brutalist: Svimlende ambisjoner</title>
-      <description><![CDATA[10 ganger Oscar-nominerte «The Brutalist» er et stort og mektig drama som gjør inntrykk.]]></description>
-      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/2fe17513-1e1b-4385-8262-34b3e8b647d9_0_ID192MP3.mp3</guid>
-      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/2fe17513-1e1b-4385-8262-34b3e8b647d9_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
-      <itunes:duration>29:15</itunes:duration>
-      <pubDate>Thu, 27 Feb 2025 14:00:00 +0100</pubDate>
-      <itunes:image href="https://gfx.nrk.no/1EK9cdVrg-ap2oWVjX2MTA3yrm5kqG1T8UVWfHd9mq9g.jpg"/>
-    </item>
-    <item>
-      <title>The White Lotus S3: Djevelsk god satire</title>
-      <description><![CDATA[Det er ren TV-luksus å bli servert nok en saftig runde med «The White Lotus» på Max. Sigurd triller terningkast 5!]]></description>
-      <guid isPermaLink="false">https://podkast.nrk.no/fil/filmpolitiet/21e47752-5873-4596-92e1-2b07c93bf754_0_ID192MP3.mp3</guid>
-      <enclosure url="https://podkast.nrk.no/fil/filmpolitiet/21e47752-5873-4596-92e1-2b07c93bf754_0_ID192MP3.mp3" length="0" type="audio/mpeg"/>
-      <itunes:duration>34:07</itunes:duration>
-      <pubDate>Thu, 20 Feb 2025 14:00:00 +0100</pubDate>
-      <itunes:image href="https://gfx.nrk.no/4OGA1QLLcZ8NjdVfg19e9QDUTD-j6wicIPH5bMIceRfw.jpg"/>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
Feeds seem to vary a bit how custom seasons are used. On Filmpolitiet specifically any spinoff series (ex. [Vi må snakke om](https://radio.nrk.no/podkast/filmpolitiet/sesong/vi-maa-snakke-om) or [Wheel of time spesial](https://radio.nrk.no/podkast/filmpolitiet/sesong/the-wheel-of-time-spesial)) are added as standalone season that are not included in the "main" `siste` feed.

To allow these spinoffs to show up we switch series from using `LATEST_SEASON` (`[0]`) to `null` which seems to make it include newest episodes irregardless of which season/spinoff they might belong to.