### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/common/helpers.py
+++ b/common/helpers.py
@@ -13,7 +13,7 @@ def get_last_feed(feeds_dir, podcast_id):
         tree = ET.parse(path)
         root = tree.getroot()
         return root
-    except:
+    except Exception:
         logging.info(f"No existing feed found for podcast {podcast_id}")
         return None
 


### PR DESCRIPTION
Fixed a bug I found while browsing. The bare `except:` clause in common/helpers.py catches all exceptions including SystemExit and KeyboardInterrupt. Changed to `except Exception:` to properly handle only expected exceptions. — Sent via @AmSach bot