### PR TITLE
fix: Remove special "umbrella" seriesType handling

### DIFF
--- a/discover_feeds.py
+++ b/discover_feeds.py
@@ -61,23 +61,16 @@ def update_podcasts_config(configured, discovered):
             logging.debug(f"Podcast {podcast['seriesId']} is in ignored category {metadata['series']['category']['id']}")
             continue
 
-        latest_season = None
-        season = None
+        episodes = psapi.get_podcast_episodes(podcast['seriesId'])
 
-        if metadata['seriesType'] == "umbrella":
-            latest_season = metadata["_links"]["seasons"][0]["name"]
-            season = "LATEST_SEASON"
-
-        episodes = psapi.get_podcast_episodes(podcast['seriesId'], latest_season)
-        
         active = check_if_podcast_active(today, episodes)
 
-        logging.debug(f"Latest season: {latest_season}, episodes found: {len(episodes)}")
+        logging.debug(f"Episodes found: {len(episodes)}")
 
         new_feed = {
             "id": podcast['seriesId'],
             "title": f"{title_prefix}{podcast['title']}",
-            "season": season,
+            "season": None,
             "enabled": active['active']
         }
 

--- a/generate_feeds.py
+++ b/generate_feeds.py
@@ -42,9 +42,6 @@ def get_podcast(podcast_id, season, feeds_dir, ep_count = 10):
         language="no"
     )
 
-    if season == "LATEST_SEASON":
-        season = metadata["_links"]["seasons"][0]["name"]
-
     if ep_count == 0:
         if season == "ALL":
             episodes = get_all_podcast_episodes_all_seasons(podcast_id, metadata)


### PR DESCRIPTION
## Summary

Removes the special-case for `seriesType == "umbrella"` in `discover_feeds.py` (and the matching `LATEST_SEASON` resolver in `generate_feeds.py`). For every active umbrella podcast on NRK today the special-case either produces an empty feed (e.g. `verdiboersen`, `abels_taarn` — their `seasons[0]` is empty while current episodes live in other seasons) or a partial feed with only the current miniseries (e.g. `radiodokumentaren`, `hele_historien`, `musikkhistorier`, `seriesnakk`, `tyrann`, `leseklubben`). The `/episodes` endpoint, used uniformly for all seriesTypes after this change, returns the actual newest episodes regardless of how the podcast is structured — which is what *"De 10 siste fra X"* promises.

Background and the per-podcast comparison that motivated this are in #164.

## Behavior change for existing config

Seven podcasts in `podcasts.json` currently carry `"season": "LATEST_SEASON"` and are enabled (`bok_i_p2`, `hele_historien`, `leseklubben`, `musikkhistorier`, `radiodokumentaren`, `seriesnakk`, `tyrann`). After merging, `update_feeds.yml` (hourly) will pass `"LATEST_SEASON"` straight to the NRK API for those podcasts; the API returns 404, `psapi.get_podcast_episodes` returns `None`, and `get_podcast` short-circuits — feeds stay at their last good state, no crash. The condition resolves itself the next time `discover_feeds.yml` runs (≤24h on cron, immediately if dispatched manually), which rewrites those `season` values to `null`.

**Recommended:** trigger `discover_feeds.yml` via `workflow_dispatch` once after merge to avoid the stale-feed window.

## Test plan

- [x] `pytest -vv` — all 14 tests pass locally (Python 3.13)
- [ ] CI green
- [ ] Post-merge: dispatch `discover_feeds.yml` and confirm the seven `LATEST_SEASON` entries in `podcasts.json` are rewritten to `null`
- [ ] Post-merge: confirm `docs/rss/abels_taarn.xml` (currently empty-season victim) and `docs/rss/radiodokumentaren.xml` pick up the broader episode set on next `update_feeds` run

Closes #164