### PR TITLE
feat: Prepend season name to umbrella podcast episode titles

### DIFF
--- a/generate_feeds.py
+++ b/generate_feeds.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from podgen import Podcast, Episode, Media
 from dateutil import parser
@@ -11,6 +12,42 @@ podgen_agent = f"nrk-pod-feeder v{get_version()} (with help from python-podgen)"
 podcasts_cfg_file = "podcasts.json"
 filter_teasers = True
 web_url = "https://sindrel.github.io/nrk-pod-feeds"
+
+# Season titles that carry no useful information (calendar buckets, "Sesong N",
+# generic catch-alls) and should not be prepended to episode titles.
+_GENERIC_SEASON_PATTERNS = [
+    re.compile(r"^Sesong\s+\d+$", re.I),
+    re.compile(r"^(Andre episoder|Siste|Annet)$", re.I),
+    re.compile(r"^[12]\d{3}$"),
+    re.compile(r"^(Januar|Februar|Mars|April|Mai|Juni|Juli|August|September|Oktober|November|Desember)\s+\d{4}$", re.I),
+    re.compile(r"^\d\.?\s*(kvartal|halvår)\s+\d{4}$", re.I),
+]
+
+
+def _season_adds_info(season, episode_title):
+    if not season or any(p.match(season) for p in _GENERIC_SEASON_PATTERNS):
+        return False
+    s = season.lower()
+    t = episode_title.lower()
+    if s in t:
+        return False
+    # "Lydboka: «Kafka på stranden»" → also try the stripped form
+    s_stripped = re.sub(r"^(lydboka|sesongen?|serien?)[:\s]+", "", s).strip()
+    return not (s_stripped and s_stripped in t)
+
+
+def build_episode_title(episode, series_type):
+    """Prepend the season name to an umbrella-podcast episode title when the
+    season actually identifies a distinct arc or miniseries. Avoids noise from
+    calendar/generic season labels and skips podcasts where the title already
+    contains the season name."""
+    title = episode["titles"]["title"]
+    if series_type != "umbrella":
+        return title
+    season = episode.get("_links", {}).get("season", {}).get("title", "")
+    if not _season_adds_info(season, title):
+        return title
+    return f"{season}: {title}"
 
 def get_podcast(podcast_id, season, feeds_dir, ep_count = 10):
     existing_feed = get_last_feed(feeds_dir, podcast_id)
@@ -27,6 +64,7 @@ def get_podcast(podcast_id, season, feeds_dir, ep_count = 10):
         return None
 
     original_title = metadata["series"]["titles"]["title"]
+    series_type = metadata.get("seriesType")
     image = f"{metadata['series']['squareImage'][4]['url']}.jpg"
     website = metadata["_links"]["share"]["href"]
 
@@ -58,7 +96,7 @@ def get_podcast(podcast_id, season, feeds_dir, ep_count = 10):
 
     new_episode = False
     for episode in episodes:
-        episode_title = episode["titles"]["title"]
+        episode_title = build_episode_title(episode, series_type)
         episode_date = episode["date"]
         if parser.parse(episode_date) >= last_feed_update:
             logging.info(f"  Found new episode {episode_title} from {episode_date}")
@@ -73,7 +111,7 @@ def get_podcast(podcast_id, season, feeds_dir, ep_count = 10):
         logging.info(f"Episode #{ep_i}:")
 
         episode_id = episode["episodeId"]
-        episode_title = episode["titles"]["title"]
+        episode_title = build_episode_title(episode, series_type)
         episode_subtitle = episode["titles"]["subtitle"]
         episode_image = f"{episode['squareImage'][4]['url']}.jpg"
         duration = episode["durationInSeconds"]

--- a/test_generate_feeds.py
+++ b/test_generate_feeds.py
@@ -24,3 +24,34 @@ def test_get_podcast_void():
 
     podcast = get_podcast(podcast_id, season_id, feeds_dir, 10)
     assert podcast == None
+
+
+def _ep(title, season_title):
+    return {"titles": {"title": title}, "_links": {"season": {"title": season_title}}}
+
+
+def test_build_episode_title_standard_unchanged():
+    assert build_episode_title(_ep("KI i krig", "Sesong 2026"), "standard") == "KI i krig"
+
+
+def test_build_episode_title_umbrella_prepends_season():
+    assert build_episode_title(
+        _ep("Guds plan med det hele (5:5)", "Demonutdriveren"), "umbrella"
+    ) == "Demonutdriveren: Guds plan med det hele (5:5)"
+
+
+def test_build_episode_title_umbrella_skips_generic_season():
+    # "Andre episoder" / calendar buckets / "Sesong N" carry no info
+    assert build_episode_title(_ep("Maria Sand", "Andre episoder"), "umbrella") == "Maria Sand"
+    assert build_episode_title(_ep("Foo", "Sesong 2025"), "umbrella") == "Foo"
+    assert build_episode_title(_ep("Foo", "Mai 2026"), "umbrella") == "Foo"
+    assert build_episode_title(_ep("Foo", "2. kvartal 2026"), "umbrella") == "Foo"
+
+
+def test_build_episode_title_umbrella_skips_when_title_contains_season():
+    # tyrann case — title already says "Khomeini"
+    assert build_episode_title(_ep("Khomeini (6:6)", "Khomeini"), "umbrella") == "Khomeini (6:6)"
+    # leseklubben case — season has "Lydboka:" prefix, title has the book name
+    assert build_episode_title(
+        _ep("«Kafka på stranden» (41:49)", "Lydboka: «Kafka på stranden»"), "umbrella"
+    ) == "«Kafka på stranden» (41:49)"


### PR DESCRIPTION
## Summary

For `seriesType == "umbrella"` podcasts, each "season" usually identifies a distinct arc or miniseries — but the episode title alone (`"Guds plan med det hele (5:5)"`, `"6: Arven"`, `"– Jeg er som Joakim (Q&A)"`) leaves a listener no clue which story they belong to. This change prepends the season title with a `:` separator when, and only when, the season actually adds information.

The helper `build_episode_title` returns the original title untouched when:

- The podcast isn't umbrella-typed (so `standard` / `sequential` feeds — where seasons are calendar buckets like `"Mai 2026"` or `"Sesong 2026"` — stay unchanged).
- The season name matches a "generic" pattern: `^Sesong N$`, `Andre episoder` / `Siste` / `Annet`, bare years (`"2025"`), month-year (`"Mai 2026"`), quarter-year (`"2. kvartal 2026"`).
- The episode title already contains the season name (case-insensitive). The check also strips a leading `Lydboka:` / `Sesongen:` / `Serien:` prefix from the season before comparing, so Leseklubben's `"Lydboka: «Kafka på stranden»"` season correctly matches its `"«Kafka på stranden» (41:49)"` episodes.

## Before / after for currently-enabled umbrella podcasts

| Podcast | Before | After |
|---|---|---|
| `radiodokumentaren` | `Guds plan med det hele (5:5)` | `Demonutdriveren: Guds plan med det hele (5:5)` |
| `abels_taarn` | `Send en beskjed til fortida` | `Forskningsfronten: Send en beskjed til fortida` |
| `hele_historien` | `Legens fall (4:4)` | `I legens grep: Legens fall (4:4)` |
| `musikkhistorier` | `6: Arven` | `Miles Davis – bak mytene: 6: Arven` |
| `seriesnakk` | `– Jeg er som Joakim (Q&A)` | `LIS: – Jeg er som Joakim (Q&A)` |
| `verdiboersen` (`KI - utopiene…`) | `Den gode (3:3)` | `KI - utopiene og dystopiene: Den gode (3:3)` |
| `verdiboersen` (`Andre episoder`) | `USA vakler — vår verden forsvinner` | `USA vakler — vår verden forsvinner` *(generic season skipped)* |
| `bok_i_p2` | `Maria Sand` | `Maria Sand` *(generic season skipped)* |
| `tyrann` | `Khomeini (6:6)` | `Khomeini (6:6)` *(title already contains season)* |
| `leseklubben` | `«Kafka på stranden» (41:49)` | `«Kafka på stranden» (41:49)` *(title already contains book)* |

Longest enriched title in this set: 50 chars (`Forskningsfronten: Slik lagrer hjernen din minner`), well within typical podcast-app limits.

## Notes

- Independent of #165 (umbrella-removal). The two PRs touch disjoint regions of `generate_feeds.py`; merge order doesn't matter.
- The same logic could in principle move into `discover_feeds.py`, but title rendering belongs at feed-build time so a future tweak to the rule re-runs everywhere on the next `update_feeds` cycle without needing a discovery pass.

## Test plan

- [x] `pytest -vv` — 18 tests pass locally (4 new unit tests for `build_episode_title`)
- [ ] CI green
- [ ] Spot-check one umbrella feed post-merge (e.g. `docs/rss/radiodokumentaren.xml`) confirms the `<title>` elements carry the season prefix