### PR TITLE
Re-enable Radio Mørch feed

### DIFF
--- a/podcasts.json
+++ b/podcasts.json
@@ -1210,9 +1210,9 @@
         "id": "radio_moerch",
         "title": "De 10 siste fra Radio Mørch",
         "season": null,
-        "enabled": false,
-        "ignore": true,
-        "hidden": true
+        "enabled": true,
+        "ignore": false,
+        "hidden": false
     },
     {
         "id": "radio_utslagsnes",


### PR DESCRIPTION
Radio Mørch has resumed with a new season (Mørch og VM, with World Cup preparations) but was previously auto-marked obsolete during its dormant gap.

The `ignore` flag prevents the discovery routine from ever re-evaluating it, so it stays parked even though it's active again. This PR clears `ignore`/`hidden` and sets `enabled: true`. The `season` is left as `null` so the discovery routine manages it going forward.