### PR TITLE
fix: Fetch episodes across all seasons for umbrella podcasts

### DIFF
--- a/discover_feeds.py
+++ b/discover_feeds.py
@@ -61,18 +61,18 @@ def update_podcasts_config(configured, discovered):
             logging.debug(f"Podcast {podcast['seriesId']} is in ignored category {metadata['series']['category']['id']}")
             continue
 
-        latest_season = None
         season = None
 
         if metadata['seriesType'] == "umbrella":
-            latest_season = metadata["_links"]["seasons"][0]["name"]
             season = "LATEST_SEASON"
 
-        episodes = psapi.get_podcast_episodes(podcast['seriesId'], latest_season)
+        # NRK's flat /episodes endpoint already merges the most recent episodes across
+        # all seasons in date order, so we never resolve a single "latest season".
+        episodes = psapi.get_podcast_episodes(podcast['seriesId'])
         
         active = check_if_podcast_active(today, episodes)
 
-        logging.debug(f"Latest season: {latest_season}, episodes found: {len(episodes)}")
+        logging.debug(f"Season: {season}, episodes found: {len(episodes)}")
 
         new_feed = {
             "id": podcast['seriesId'],

--- a/generate_feeds.py
+++ b/generate_feeds.py
@@ -43,7 +43,9 @@ def get_podcast(podcast_id, season, feeds_dir, ep_count = 10):
     )
 
     if season == "LATEST_SEASON":
-        season = metadata["_links"]["seasons"][0]["name"]
+        # NRK's flat /episodes endpoint already merges the most recent episodes across
+        # all seasons in date order, so no single "latest season" needs resolving.
+        season = None
 
     if ep_count == 0:
         if season == "ALL":

--- a/podcasts.json
+++ b/podcasts.json
@@ -19,7 +19,7 @@
         "id": "abels_taarn",
         "title": "De 10 siste fra Abels tårn",
         "season": "LATEST_SEASON",
-        "enabled": false
+        "enabled": true
     },
     {
         "id": "andakten",
@@ -1722,7 +1722,7 @@
         "id": "verdiboersen",
         "title": "De 10 siste fra Verdibørsen",
         "season": "LATEST_SEASON",
-        "enabled": false
+        "enabled": true
     },
     {
         "id": "vg3",

--- a/test_generate_feeds.py
+++ b/test_generate_feeds.py
@@ -24,3 +24,20 @@ def test_get_podcast_void():
 
     podcast = get_podcast(podcast_id, season_id, feeds_dir, 10)
     assert podcast == None
+
+def test_get_podcast_latest_season_matches_unscoped_fetch(tmp_path):
+    # Regression test: LATEST_SEASON must fetch recent episodes across all seasons
+    # via NRK's flat /episodes endpoint -- exactly as season=None does -- instead of
+    # resolving a single season that may be an empty placeholder (which silently
+    # emptied the Abels tårn feed). Asserting the two paths agree keeps the test from
+    # depending on how NRK happens to split the series into seasons at any moment.
+    podcast_id = "abels_taarn"
+
+    # tmp_path is an empty feeds_dir, so no prior lastBuildDate suppresses the episodes.
+    # get_podcast only reads feeds_dir, so both calls can share the same empty dir.
+    latest = get_podcast(podcast_id, "LATEST_SEASON", tmp_path, 10)
+    unscoped = get_podcast(podcast_id, None, tmp_path, 10)
+
+    assert latest
+    assert latest.episodes
+    assert [e.title for e in latest.episodes] == [e.title for e in unscoped.episodes]


### PR DESCRIPTION
<!-- Suggested PR title: fix: Fetch episodes across all seasons for umbrella podcasts -->

## Why

The **Abels tårn** feed silently stopped updating around 2026-05-04. My podcast queue is pretty long these days, so I didn't notice until the last week that I hadn't gotten any new Abels Tårn podcasts in quite a while. This PR traces the cause and fixes it, and re-enables the feeds it had silently disabled.

## What was happening

For "umbrella" podcasts (multi-season series), both the generator and the discovery routine resolve a single "latest" season by taking the *first* entry of NRK's season list and querying only that season: [`generate_feeds.py` L45-46](https://github.com/sindrel/nrk-pod-feeds/blob/b868eb2efa43cfc9d22edbf29dc1ea1042ebaac4/generate_feeds.py#L45-L46) and [`discover_feeds.py` L68-71](https://github.com/sindrel/nrk-pod-feeds/blob/b868eb2efa43cfc9d22edbf29dc1ea1042ebaac4/discover_feeds.py#L68-L71). This assumes NRK orders the `seasons` array newest-first.

For Abels Tårn that assumption no longer holds. NRK now lists an **empty** season literally named `"2025"` at position 0. So the discovery routine resolved `"2025"`, fetched zero episodes, concluded the podcast was inactive, and set `enabled: false`. The generator then skipped it for the same reason. The podcast itself never stopped — it has been publishing weekly the whole time (into themed seasons such as `taarnet` and `forskningsfronten`).

Testing more of the configured podcasts, I found the same failure had already quietly disabled **Verdibørsen** (empty placeholder season `"202512"` at position 0), which corroborates that this may be a general problem with the workaround rather than a one-off.

## What I think changed on NRK's side

I can't inspect NRK's PSAPI history, so this is a hypothesis, but the evidence fits: the `LATEST_SEASON` workaround was introduced years ago because the season-scoped endpoint was the reliable way to get a series' most recent episodes. Today, the *season-agnostic* endpoint — `GET /radio/catalog/podcast/<id>/episodes?sort=desc` — already seems to return exactly what we want: the most recent episodes **merged and interleaved across all seasons, in date order**. For Abels tårn it correctly interleaves `taarnet` and `forskningsfronten`; the flat list is also what the code already uses for every non-umbrella podcast (`season: null`).

In other words, it looks like NRK at some point changed what the `/episodes` endpoint returns for umbrella series (or fixed it), and as a result the `LATEST_SEASON` / "pick season 0" workaround is probably no longer necessary — it even appears actively harmful, because NRK also started placing empty year-labelled placeholder seasons at position 0 in some podcasts.

## The fix

Route `LATEST_SEASON` through the flat `/episodes` endpoint — i.e. treat it exactly as `season: null` is already treated — instead of resolving and querying a single season. No new aggregation logic is needed; NRK's API does the merging.

To keep this a behaviour-preserving change everywhere except the broken cases, I compared the flat endpoint against the current season-0 resolution for **all 25 podcasts configured with `LATEST_SEASON`**:

- **22** already agree between the two endpoints → no change.
- **Abels tårn** and **Verdibørsen** → fixed (both re-enabled here).
- **Kringkastingsorkestret** → minor improvement (NRK's season-scoped endpoint returns same-day episodes in ascending order; the flat endpoint sorts them correctly).

## Open question: is `LATEST_SEASON` still worth keeping?

This PR keeps the `LATEST_SEASON` sentinel in `podcasts.json` and just changes how it is resolved, to keep the diff small and behaviour-preserving. But it is worth deciding deliberately, because after this change the setting no longer affects the generated feeds or the listing page at all — `LATEST_SEASON` and `null` produce identical output. Its only remaining effect is inside the discovery routine's change-detection: discovery re-derives `LATEST_SEASON` for umbrella series each run, so storing that value keeps the stored config matching what discovery computes and avoids a spurious "Updated podcast" changelog entry. That is a somewhat self-referential purpose — the setting mainly exists to keep itself stable.

